### PR TITLE
Sentence case "Health and wellbeing" to match other case studies

### DIFF
--- a/case-studies/posts/2024/05/08/dpm.qmd
+++ b/case-studies/posts/2024/05/08/dpm.qmd
@@ -3,7 +3,7 @@ title: Forecasting the Health Needs of a Changing Population
 description: |
   Taking NHS usage of the 1 million people in and around Bristol, then combining with population forecasts into a modelling framework has created a sophisticated but interprettable 20-year forecast for use by healthcare leaders.
 categories:
-  - Health and Wellbeing
+  - Health and wellbeing
   - Forecasting
 author: Luke Shaw (BNSSG ICB), Rich Wood (BNSSG ICB, University of Bath), Christos Vasilakis (University of Bath), Zehra Onen Dumlu (University of Bath)
 date: last-modified


### PR DESCRIPTION
Previous case studies have used the category `Health and wellbeing`

<img width="137" alt="Capture" src="https://github.com/user-attachments/assets/5cd6c779-72cf-48cd-943b-6b2e2c5f4b6f">
